### PR TITLE
Add copy button to copy JSON to clipboard

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
-// Set the inner HTML first
 document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
    <form id="csvForm">
       <input type="file" id="csvInput" accept=".csv" />
       <input type="submit" value="Submit" />
     </form>
     <textarea name="" id="csvResult" cols="30" rows="10"></textarea>
+    <button id="copyButton">Copy to Clipboard</button>
 `;
 
 // Now that the elements exist in the DOM, access them
@@ -12,6 +12,7 @@ import "./style.css";
 const form = document.querySelector("#csvForm")!;
 const csvFileInput = document.querySelector("#csvInput")! as HTMLInputElement;
 const textArea = document.querySelector("#csvResult")! as HTMLTextAreaElement;
+const copyButton = document.querySelector("#copyButton")! as HTMLButtonElement;
 
 form.addEventListener("submit", function (e) {
   e.preventDefault();
@@ -27,6 +28,12 @@ form.addEventListener("submit", function (e) {
   if (file) {
     reader.readAsText(file);
   }
+});
+
+copyButton.addEventListener("click", function () {
+  textArea.select();
+  document.execCommand("copy");
+  alert("Copied to clipboard!");
 });
 
 interface CSVObject {


### PR DESCRIPTION
This pull request adds a copy button to the application that allows users to copy the JSON data to the clipboard. When the button is clicked, the JSON data is selected and copied to the clipboard using the `execCommand("copy")` method. Additionally, a confirmation message is displayed to notify the user that the data has been successfully copied. This enhancement improves the usability of the application by providing an easy way for users to copy the JSON data without having to manually select and copy the text. Fixes #1.